### PR TITLE
Changed sys.maxint to 2**31-1 in layers.py to avoid overflow on some 64-...

### DIFF
--- a/lib/layers.py
+++ b/lib/layers.py
@@ -36,8 +36,8 @@ class Weight(object):
 
     def load_weight(self, dir, name):
         print 'weight loaded: ' + name
-        np_values = np.load(dir + name + '.npy')
-        self.val.set_value(np_values)
+        self.np_values = np.load(dir + name + '.npy')
+        self.val.set_value(self.np_values)
 
 
 class DataLayer(object):
@@ -242,7 +242,7 @@ class DropoutLayer(object):
         self.flag_on = T.shared(np.cast[theano.config.floatX](1.0))
         self.flag_off = 1.0 - self.flag_on
 
-        seed_this = DropoutLayer.seed_common.randint(0, sys.maxint)
+        seed_this = DropoutLayer.seed_common.randint(0, 2**31-1)
         mask_rng = theano.tensor.shared_randomstreams.RandomStreams(seed_this)
         self.mask = mask_rng.binomial(n=1, p=self.prob_keep, size=input.shape)
 


### PR DESCRIPTION
...bit machines. Also, made np_values a consistent class member for the Weight class (also in layers.py).
