### PR TITLE
Add cropping to train and validation when para_load = False

### DIFF
--- a/proc_load.py
+++ b/proc_load.py
@@ -89,7 +89,6 @@ def fun_load(config, sock_data=5000):
     # send_queue is only for sending
 
     # if need to do random crop and mirror
-    flag_randproc = not config['use_data_layer']
     flag_batch = config['batch_crop_mirror']
 
     drv.init()
@@ -120,10 +119,9 @@ def fun_load(config, sock_data=5000):
         data = hkl.load(hkl_name) - img_mean
         # print 'load ', time.time() - bgn_time
 
-        if flag_randproc:
-            param_rand = recv_queue.get()
+        param_rand = recv_queue.get()
 
-            data = crop_and_mirror(data, param_rand, flag_batch=flag_batch)
+        data = crop_and_mirror(data, param_rand, flag_batch=flag_batch)
 
         gpu_data.set(data)
 

--- a/train.py
+++ b/train.py
@@ -18,7 +18,7 @@ from train_funcs import (unpack_configs, adjust_learning_rate,
 def train_net(config):
 
     # UNPACK CONFIGS
-    (flag_para_load, flag_datalayer, train_filenames, val_filenames,
+    (flag_para_load, train_filenames, val_filenames,
      train_labels, val_labels, img_mean) = unpack_configs(config)
 
     if flag_para_load:
@@ -98,8 +98,7 @@ def train_net(config):
         if flag_para_load:
             # send the initial message to load data, before each epoch
             load_send_queue.put(str(train_filenames[minibatch_range[0]]))
-            if not flag_datalayer:
-                load_send_queue.put(get_rand3d())
+            load_send_queue.put(get_rand3d())
 
             # clear the sync before 1st calc
             load_send_queue.put('calc_finished')
@@ -120,7 +119,7 @@ def train_net(config):
                                        count, minibatch_index,
                                        minibatch_range, batch_size,
                                        train_filenames, train_labels,
-                                       flag_para_load, flag_datalayer,
+                                       flag_para_load,
                                        config['batch_crop_mirror'],###BUG 1 FIXED#####
                                        send_queue=load_send_queue,
                                        recv_queue=load_recv_queue)
@@ -142,7 +141,7 @@ def train_net(config):
         this_validation_error, this_validation_loss = get_val_error_loss(
             rand_arr, shared_x, shared_y,
             val_filenames, val_labels,
-            flag_datalayer, flag_para_load,
+            flag_para_load,
             batch_size, validate_model,
             send_queue=load_send_queue, recv_queue=load_recv_queue)
 

--- a/train.py
+++ b/train.py
@@ -121,6 +121,7 @@ def train_net(config):
                                        minibatch_range, batch_size,
                                        train_filenames, train_labels,
                                        flag_para_load, flag_datalayer,
+                                       config['batch_crop_mirror'],###BUG 1 FIXED#####
                                        send_queue=load_send_queue,
                                        recv_queue=load_recv_queue)
 

--- a/train_2gpu.py
+++ b/train_2gpu.py
@@ -23,7 +23,7 @@ from train_funcs import (unpack_configs, adjust_learning_rate,
 def train_net(config, private_config):
 
     # UNPACK CONFIGS
-    (flag_para_load, flag_datalayer, train_filenames, val_filenames,
+    (flag_para_load, train_filenames, val_filenames,
      train_labels, val_labels, img_mean) = \
         unpack_configs(config, ext_data=private_config['ext_data'],
                        ext_label=private_config['ext_label'])
@@ -172,8 +172,7 @@ def train_net(config, private_config):
         if flag_para_load:
             # send the initial message to load data, before each epoch
             load_send_queue.put(str(train_filenames[minibatch_range[0]]))
-            if not flag_datalayer:
-                load_send_queue.put(get_rand3d())
+            load_send_queue.put(get_rand3d())
 
             # clear the sync before 1st calc
             load_send_queue.put('calc_finished')
@@ -194,7 +193,7 @@ def train_net(config, private_config):
                                        count, minibatch_index,
                                        minibatch_range, batch_size,
                                        train_filenames, train_labels,
-                                       flag_para_load, flag_datalayer,
+                                       flag_para_load,
                                        config['batch_crop_mirror'],###BUG 1 FIXED#####
                                        send_queue=load_send_queue,
                                        recv_queue=load_recv_queue)
@@ -256,7 +255,7 @@ def train_net(config, private_config):
         this_val_error, this_val_loss = get_val_error_loss(
             rand_arr, shared_x, shared_y,
             val_filenames, val_labels,
-            flag_datalayer, flag_para_load,
+            flag_para_load,
             batch_size, validate_model,
             send_queue=load_send_queue, recv_queue=load_recv_queue)
 

--- a/train_2gpu.py
+++ b/train_2gpu.py
@@ -195,6 +195,7 @@ def train_net(config, private_config):
                                        minibatch_range, batch_size,
                                        train_filenames, train_labels,
                                        flag_para_load, flag_datalayer,
+                                       config['batch_crop_mirror'],###BUG 1 FIXED#####
                                        send_queue=load_send_queue,
                                        recv_queue=load_recv_queue)
 

--- a/train_funcs.py
+++ b/train_funcs.py
@@ -6,6 +6,7 @@ import numpy as np
 
 import hickle as hkl
 
+from proc_load import crop_and_mirror  ########BUG1 FIXED##############
 
 def proc_configs(config):
     if not os.path.exists(config['weights_dir']):
@@ -98,6 +99,14 @@ def get_val_error_loss(rand_arr, shared_x, shared_y,
                     send_queue.put(np.float32([0.5, 0.5, 0]))
         else:
             val_img = hkl.load(str(val_filenames[val_index]))
+            ####BUG 1 FIXED(INPUT SIZE DIFFERENT AND MATRIX DIMENSION MISMATCH BUG)##
+            if flag_datalayer:
+                param_rand = [0.5,0.5,0]
+            else:
+                param_rand = get_rand3d()
+               
+            val_img = crop_and_mirror(val_img, param_rand, flag_batch=True)
+            #######################################################################            
             shared_x.set_value(val_img)
 
         shared_y.set_value(val_labels[val_index * batch_size:
@@ -158,6 +167,14 @@ def train_model_wrap(train_model, shared_x, shared_y, rand_arr, img_mean,
 
     else:
         batch_img = hkl.load(str(train_filenames[minibatch_index])) - img_mean
+        ###BUG 1 FIXED:(INPUT SIZE DIFFERENT AND MATRIX DIMENSION MISMATCH BUG) ##
+        if flag_datalayer:
+            param_rand = [0.5,0.5,0]
+        else:
+            param_rand = get_rand3d()
+           
+        batch_img = crop_and_mirror(batch_img, param_rand, flag_batch=True)
+        #####################################################################           
         shared_x.set_value(batch_img)
 
     batch_label = train_labels[minibatch_index * batch_size:

--- a/train_funcs.py
+++ b/train_funcs.py
@@ -100,12 +100,9 @@ def get_val_error_loss(rand_arr, shared_x, shared_y,
         else:
             val_img = hkl.load(str(val_filenames[val_index]))
             ####BUG 1 FIXED(INPUT SIZE DIFFERENT AND MATRIX DIMENSION MISMATCH BUG)##
-            if flag_datalayer:
-                param_rand = [0.5,0.5,0]
-            else:
-                param_rand = get_rand3d()
-               
-            val_img = crop_and_mirror(val_img, param_rand, flag_batch=True)
+            if not flag_datalayer:
+                param_rand = [0.5,0.5,0]              
+                val_img = crop_and_mirror(val_img, param_rand, flag_batch=True)
             #######################################################################            
             shared_x.set_value(val_img)
 
@@ -148,7 +145,8 @@ def get_rand3d():
 def train_model_wrap(train_model, shared_x, shared_y, rand_arr, img_mean,
                      count, minibatch_index, minibatch_range, batch_size,
                      train_filenames, train_labels,
-                     flag_para_load, flag_datalayer,
+                     flag_para_load, flag_datalayer, 
+                     flag_batch,######BUG 1 FIXED########
                      send_queue=None, recv_queue=None):
 
     if flag_para_load:
@@ -168,12 +166,9 @@ def train_model_wrap(train_model, shared_x, shared_y, rand_arr, img_mean,
     else:
         batch_img = hkl.load(str(train_filenames[minibatch_index])) - img_mean
         ###BUG 1 FIXED:(INPUT SIZE DIFFERENT AND MATRIX DIMENSION MISMATCH BUG) ##
-        if flag_datalayer:
-            param_rand = [0.5,0.5,0]
-        else:
-            param_rand = get_rand3d()
-           
-        batch_img = crop_and_mirror(batch_img, param_rand, flag_batch=True)
+        if not flag_datalayer:
+            param_rand = get_rand3d()           
+            batch_img = crop_and_mirror(batch_img, param_rand, flag_batch=flag_batch)
         #####################################################################           
         shared_x.set_value(batch_img)
 


### PR DESCRIPTION
Before fixing this bug, when use para_load = False, the size of input data that was set to shared_x in every iteration does not match the correct input size of the model, giving a dimension mismatch error when doing matrix-matrix multiplication.

The reason of the bug is that there's no cropping when para_load is False in two places, i.e. in get_val_error_loss() and train_model_wrap(). However, when para_load is True, there's cropping inside the loading process.

After fixing the bug, the cropping is active under both condition.
